### PR TITLE
Allow argument 'newdata' in predict method

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -5,8 +5,8 @@ QuickReg <- function(X, Y) {
     .Call('_bdfm_QuickReg', PACKAGE = 'bdfm', X, Y)
 }
 
-UVreg <- function(x, y) {
-    .Call('_bdfm_UVreg', PACKAGE = 'bdfm', x, y)
+UVreg <- function(x, y, rm_outlier = 0L) {
+    .Call('_bdfm_UVreg', PACKAGE = 'bdfm', x, y, rm_outlier)
 }
 
 comp_form <- function(B) {

--- a/R/auto_process.R
+++ b/R/auto_process.R
@@ -1,16 +1,27 @@
 # Automatic selection for logs and differences
 
-log_diff <- function(y){
-  fq <- get_freq(y)
-  rmdr  <- median(which(is.finite(y))%%fq)
-  indx  <- seq(1, length(y))%%fq == rmdr
-  y <- y[indx]
-  ts_reg <- UVreg(x = y[-length(y)] - mean(y, na.rm = TRUE), y = y[-1] - mean(y, na.rm = TRUE))
+log_diff <- function(y, fast = FALSE){
+  if(!fast){
+    fq <- get_freq(y)
+    rmdr  <- median(which(is.finite(y))%%fq)
+    indx  <- seq(1, length(y))%%fq == rmdr
+    y <- y[indx]
+  }
+  # 1st test: test AR(1) coefficient
+  # rm outlier here reffers to how many iterations of removing outliers should we do. The threshold is set at 5 sd.
+  ts_reg <- UVreg(x = y[-length(y)] - mean(y, na.rm = TRUE), y = y[-1] - mean(y, na.rm = TRUE), rm_outlier = 2)
   
-  take_log  <- (ts_reg$B - ts_reg$sd)>1 && !any(y<0, na.rm = TRUE)
-  take_diff <- !(ts_reg$B + 3*ts_reg$sd)<1
+  # 2nd test: does the data grow over time? Normally the first test would get this, but often with super noisy
+  # daily data it misses. This is a sort of fall-back.
+  lin_reg <- UVreg(x = seq(length(y)), y = y - mean(y, na.rm = TRUE), rm_outlier = 2)
   
-  return(c(take_log, take_diff))
+  take_diff <- !(ts_reg$B + 3*ts_reg$sd)<1 || (abs(lin_reg$B) - 2*lin_reg$sd)>0
+  take_log  <- take_diff && !any(y<0, na.rm = TRUE)  #(ts_reg$B - ts_reg$sd)>1 && !any(y<0, na.rm = TRUE)
+  
+  log_diff <- c(take_log, take_diff)
+  names(log_diff) <- c("Take Logs", "Take Diffs")
+  
+  return(log_diff)
 }
 
 

--- a/R/dfm-methods.R
+++ b/R/dfm-methods.R
@@ -19,8 +19,62 @@ adjusted <- function(x) {
 # methods
 #' @export
 #' @method predict dfm
-predict.dfm <- function(object, ...) {
-  object$values
+predict.dfm <- function(object, newdata = NULL, return_intermediates = FALSE, ...) {
+  if(is.null(newdata)){
+    return(object$values)
+  }else{
+    if(NCOL(object$values) != NCOL(newdata)){
+      stop("'newdata' must include the same observable series as the original model was fitted with.")
+    }
+    
+    # logs
+    if (!is.null(object$logs)) {
+      newdata[, object$logs] <- log(newdata[, object$logs])
+    }
+    
+    # differences
+    if (!is.null(object$diffs)) {
+      newdata_lev <- newdata
+      newdata[, object$diffs] <- sapply(object$diffs, mf_diff, fq = object$freq, Y = newdata)
+    }
+    
+    # drop outliers
+    newdata[abs(scale(newdata)) > object$outlier_threshold] <- NA
+    
+    #scale
+    if (object$scale) {
+      newdata <- 100*scale(newdata)
+      y_scale  <- attr(newdata, "scaled:scale")
+      y_center <- attr(newdata, "scaled:center")
+    }
+    
+    est <- DSmooth(object$B, object$Jb, object$q, object$H, diag(object$R), newdata, object$freq, object$differences)
+    
+    if(object$scale){
+      est$Ys <- (matrix(1, nrow(est$Ys), 1) %x% t(y_scale)) * (est$Ys / 100) + (matrix(1, nrow(est$Ys), 1) %x% t(y_center))
+    }
+    
+    # undo differences
+    if (!is.null(object$diffs)) {
+      est$Ys[,object$diffs] <- sapply(object$diffs, FUN = level, fq = object$freq, Y_lev = newdata_lev, vals = est$Ys)
+    }
+    
+    # undo logs
+    if (!is.null(object$logs)) {
+      est$Ys[,object$logs] <- exp(est$Ys[,object$logs])
+    }
+    
+    #Return intermediate values of low frequency data?
+    if (length(unique(object$freq))>1 && !return_intermediates){
+      est$Ys[,which(object$freq != 1)] <- do.call(cbind, lapply(X = which(object$freq != 1), FUN = drop_intermediates,
+                                                             freq = object$freq, Y_raw = newdata, vals = est$Ys))
+    }
+    
+    colnames(est$Ys) <- colnames(newdata)
+    
+    return(est$Ys)
+  }
+  
 }
 
 #' @export

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -19,14 +19,15 @@ BEGIN_RCPP
 END_RCPP
 }
 // UVreg
-List UVreg(arma::vec x, arma::vec y);
-RcppExport SEXP _bdfm_UVreg(SEXP xSEXP, SEXP ySEXP) {
+List UVreg(arma::vec x, arma::vec y, arma::uword rm_outlier);
+RcppExport SEXP _bdfm_UVreg(SEXP xSEXP, SEXP ySEXP, SEXP rm_outlierSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< arma::vec >::type x(xSEXP);
     Rcpp::traits::input_parameter< arma::vec >::type y(ySEXP);
-    rcpp_result_gen = Rcpp::wrap(UVreg(x, y));
+    Rcpp::traits::input_parameter< arma::uword >::type rm_outlier(rm_outlierSEXP);
+    rcpp_result_gen = Rcpp::wrap(UVreg(x, y, rm_outlier));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -301,7 +302,7 @@ END_RCPP
 
 static const R_CallMethodDef CallEntries[] = {
     {"_bdfm_QuickReg", (DL_FUNC) &_bdfm_QuickReg, 2},
-    {"_bdfm_UVreg", (DL_FUNC) &_bdfm_UVreg, 2},
+    {"_bdfm_UVreg", (DL_FUNC) &_bdfm_UVreg, 3},
     {"_bdfm_comp_form", (DL_FUNC) &_bdfm_comp_form, 1},
     {"_bdfm_mvrnrm", (DL_FUNC) &_bdfm_mvrnrm, 3},
     {"_bdfm_rinvwish", (DL_FUNC) &_bdfm_rinvwish, 3},


### PR DESCRIPTION
predict method now allows for the argument newdata. Because we've already estimated the model (and we use an efficient C++ disturbance smoother) results are (more or less) instant. An example:

``` r

library(bdfm)
Y <- econ_us
m <- dfm(data = econ_us[1:300,], factors = 3, pre_differenced = "A191RL1Q225SBEA", store_idx = "A191RL1Q225SBEA")
```

``` r
out_samp <- predict(m, newdata = econ_us[301:469,])
```

<sup>Created on 2019-03-25 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>
